### PR TITLE
Avoid integral division for Sørensen-Dice coefficient within StringSet

### DIFF
--- a/src/main/java/info/debatty/java/stringsimilarity/StringSet.java
+++ b/src/main/java/info/debatty/java/stringsimilarity/StringSet.java
@@ -54,6 +54,6 @@ public class StringSet {
             throw new Exception("Profiles were not created using the same kshingling object!");
         }
         
-        return 2 * this.vector.intersection(other.vector) / (this.vector.size() + other.vector.size());
+        return 2.0 * this.vector.intersection(other.vector) / (this.vector.size() + other.vector.size());
     }
 }


### PR DESCRIPTION
The `sorensenDiceSimilarity` method should now return a `double` value without having precision loss.