### PR TITLE
Prevent divide by zero errors.

### DIFF
--- a/src/main/java/info/debatty/java/stringsimilarity/MetricLCS.java
+++ b/src/main/java/info/debatty/java/stringsimilarity/MetricLCS.java
@@ -47,9 +47,13 @@ public class MetricLCS
      * @return
      */
     public final double distance(final String s1, final String s2) {
+	int mLen = Math.max(s1.length(), s2.length());
+	if (mLen == 0) {
+	    return 0;
+	}
         return 1.0
                 - (1.0 * lcs.length(s1, s2))
-                / Math.max(s1.length(), s2.length());
+                / mLen;
 
     }
 

--- a/src/main/java/info/debatty/java/stringsimilarity/NormalizedLevenshtein.java
+++ b/src/main/java/info/debatty/java/stringsimilarity/NormalizedLevenshtein.java
@@ -48,7 +48,11 @@ public class NormalizedLevenshtein implements
      * @return
      */
     public final double distance(final String s1, final String s2) {
-        return l.distance(s1, s2) / Math.max(s1.length(), s2.length());
+	int mLen = Math.max(s1.length(), s2.length());
+	if (mLen == 0) {
+	    return 0;
+	}
+        return l.distance(s1, s2) / mLen;
     }
 
     /**


### PR DESCRIPTION
MetricLCS and NormalizedLevenshtein both divide by the max string
length to produce distances. If two empty strings are used then
a division by zero occurs and NaN is returned.

This PR checks the max string length and returns a distance of 0 if the max string length is 0.