### PR TITLE
Performance: avoid spurious containsKey calls

### DIFF
--- a/src/main/java/info/debatty/java/stringsimilarity/Cosine.java
+++ b/src/main/java/info/debatty/java/stringsimilarity/Cosine.java
@@ -113,10 +113,11 @@ public class Cosine extends ShingleBased implements
 
         double agg = 0;
         for (Map.Entry<String, Integer> entry : small_profile.entrySet()) {
-            if (!large_profile.containsKey(entry.getKey())) {
+        	Integer i=large_profile.get(entry.getKey());
+            if (i==null) {
                 continue;
             }
-            agg += 1.0 * entry.getValue() * large_profile.get(entry.getKey());
+            agg += 1.0 * entry.getValue() * i;
         }
 
         return agg;

--- a/src/main/java/info/debatty/java/stringsimilarity/Damerau.java
+++ b/src/main/java/info/debatty/java/stringsimilarity/Damerau.java
@@ -62,15 +62,11 @@ public class Damerau implements MetricStringDistance {
         HashMap<Character, Integer> da = new HashMap<Character, Integer>();
 
         for (int d = 0; d < s1.length(); d++) {
-            if (!da.containsKey(s1.charAt(d))) {
-                da.put(s1.charAt(d), 0);
-            }
+            da.put(s1.charAt(d), 0);
         }
 
         for (int d = 0; d < s2.length(); d++) {
-            if (!da.containsKey(s2.charAt(d))) {
-                da.put(s2.charAt(d), 0);
-            }
+            da.put(s2.charAt(d), 0);
         }
 
         // Create the distance matrix H[0 .. s1.length+1][0 .. s2.length+1]

--- a/src/main/java/info/debatty/java/stringsimilarity/QGram.java
+++ b/src/main/java/info/debatty/java/stringsimilarity/QGram.java
@@ -67,13 +67,14 @@ public class QGram extends ShingleBased implements StringDistance {
         for (String key : union) {
             int v1 = 0;
             int v2 = 0;
-            if (profile1.containsKey(key)) {
-                v1 = profile1.get(key);
+            Integer iv1 = profile1.get(key);
+            if (iv1!=null){
+            	v1=iv1.intValue();
             }
 
-
-            if (profile2.containsKey(key)) {
-                v2 = profile2.get(key);
+            Integer iv2=profile2.get(key);
+            if (iv2!=null) {
+                v2 = iv2.intValue();
             }
             agg += Math.abs(v1 - v2);
         }

--- a/src/main/java/info/debatty/java/stringsimilarity/ShingleBased.java
+++ b/src/main/java/info/debatty/java/stringsimilarity/ShingleBased.java
@@ -106,13 +106,11 @@ abstract class ShingleBased {
         String string_no_space = SPACE_REG.matcher(string).replaceAll(" ");
         for (int i = 0; i < (string_no_space.length() - k + 1); i++) {
             String shingle = string_no_space.substring(i, i + k);
-
-            if (shingles.containsKey(shingle)) {
-                shingles.put(shingle, shingles.get(shingle) + 1);
-
+            Integer old = shingles.get(shingle);
+            if (old!=null) {
+                shingles.put(shingle, old + 1);
             } else {
                 shingles.put(shingle, 1);
-
             }
         }
 


### PR DESCRIPTION
I found some instances where we call containsKey and then get, while doing get and checking for null result is faster (only one hashmap lookup). For Damerau, we are checking if a key exists but anyway we always init with the same value. 

Great library, thanks a million for your work!