### PR TITLE
Fix typo 'developped'

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ Distance is computed as 1 - cosine similarity.
 ## Experimental
 
 ### SIFT4
-SIFT4 is a general purpose string distance algorithm inspired by JaroWinkler and Longest Common Subsequence. It was developped to produce a distance measure that matches as close as possible to the human perception of string distance. Hence it takes into account elements like character substitution, character distance, longest common subsequence etc. It was developped using experimental testing, and without theoretical background.
+SIFT4 is a general purpose string distance algorithm inspired by JaroWinkler and Longest Common Subsequence. It was developed to produce a distance measure that matches as close as possible to the human perception of string distance. Hence it takes into account elements like character substitution, character distance, longest common subsequence etc. It was developed using experimental testing, and without theoretical background.
 
 ```
 import info.debatty.java.stringsimilarity.experimental.Sift4;


### PR DESCRIPTION
Some typo 'developped' in README.md, it should be 'developed'.