### PR TITLE
Make ShingleBased class public

### DIFF
--- a/src/main/java/info/debatty/java/stringsimilarity/ShingleBased.java
+++ b/src/main/java/info/debatty/java/stringsimilarity/ShingleBased.java
@@ -51,7 +51,7 @@ import java.util.regex.Pattern;
  * @author Thibault Debatty
  */
 @Immutable
-abstract class ShingleBased {
+public abstract class ShingleBased {
 
     private static final int DEFAULT_K = 3;
 


### PR DESCRIPTION
Please make ShingleBased class public. A non public abstract class makes computing string profiles from Clojure impossible.