### PR TITLE
WeightedLevenshtein ins/del weights.

### DIFF
--- a/src/main/java/info/debatty/java/stringsimilarity/CharacterInsDelInterface.java
+++ b/src/main/java/info/debatty/java/stringsimilarity/CharacterInsDelInterface.java
@@ -1,0 +1,23 @@
+package info.debatty.java.stringsimilarity;
+
+
+/**
+ * As an adjunct to CharacterSubstitutionInterface, this interface
+ * allows you to specify the cost of deletion or insertion of a
+ * character.
+ */
+public interface CharacterInsDelInterface {
+    /**
+     * @param c The character being deleted.
+     * @return The cost to be allocated to deleting the given character,
+     * in the range [0, 1].
+     */
+    double deletionCost(char c);
+
+    /**
+     * @param c The character being inserted.
+     * @return The cost to be allocated to inserting the given character,
+     * in the range [0, 1].
+     */
+    double insertionCost(char c);
+}

--- a/src/test/java/info/debatty/java/stringsimilarity/WeightedLevenshteinTest.java
+++ b/src/test/java/info/debatty/java/stringsimilarity/WeightedLevenshteinTest.java
@@ -27,6 +27,54 @@ public class WeightedLevenshteinTest {
         assertEquals(0.5, instance.distance("String1", "Srring1"), 0.1);
         assertEquals(1.5, instance.distance("String1", "Srring2"), 0.1);
 
+        // One insert or delete.
+        assertEquals(1.0, instance.distance("Strng", "String"), 0.1);
+        assertEquals(1.0, instance.distance("String", "Strng"), 0.1);
+
+        NullEmptyTests.testDistance(instance);
+    }
+
+    @Test
+    public void testDistanceCharacterInsDelInterface() {
+        WeightedLevenshtein instance = new WeightedLevenshtein(
+                new CharacterSubstitutionInterface() {
+            public double cost(char c1, char c2) {
+                if (c1 == 't' && c2 == 'r') {
+                    return 0.5;
+                }
+                return 1.0;
+            }
+        },
+        new CharacterInsDelInterface() {
+            public double deletionCost(char c) {
+                if (c == 'i') {
+                    return 0.8;
+                }
+                return 1.0;
+            }
+
+            public double insertionCost(char c) {
+                if (c == 'i') {
+                    return 0.5;
+                }
+                return 1.0;
+            }
+        });
+
+        // Same as testDistance above.
+        assertEquals(0.0, instance.distance("String1", "String1"), 0.1);
+        assertEquals(0.5, instance.distance("String1", "Srring1"), 0.1);
+        assertEquals(1.5, instance.distance("String1", "Srring2"), 0.1);
+
+        // Cost of insert of 'i' is less than normal, so these scores are
+        // different than testDistance above.  Note that the cost of delete
+        // has been set differently than the cost of insert, so the distance
+        // call is not symmetric in its arguments if an 'i' has changed.
+        assertEquals(0.5, instance.distance("Strng", "String"), 0.1);
+        assertEquals(0.8, instance.distance("String", "Strng"), 0.1);
+        assertEquals(1.0, instance.distance("Strig", "String"), 0.1);
+        assertEquals(1.0, instance.distance("String", "Strig"), 0.1);
+
         NullEmptyTests.testDistance(instance);
     }
 }


### PR DESCRIPTION
Extend WeightedLevenshtein to have customizable insert / deletion weights.
Previously, insert / deletion weights were hardcoded at 1.0.  Customizing
them allows the caller to under-weight the insertion of a thin letter like
I or l to reflect the likelihood of OCR errors (for example).

This adds a new interface, CharacterInsDelInterface, which is an
adjunct to CharacterSubstitutionInterface.  The old behavior is preserved
if the caller does not provide a CharacterSubstitutionInterface subclass.

This also adds insert / deletion tests to the old
WeightedLevenshteinTest.testDistance, and adds a new
testDistanceCharacterInsDelInterface test.