### PR TITLE
Update Jaro-Winkler description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,10 +250,10 @@ Will produce:
 ```
 
 ## Jaro-Winkler
-Jaro-Winkler is a string edit distance that was developed in the area of record linkage (duplicate detection) (Winkler, 1990). The Jaro–Winkler distance metric is designed and best suited for short strings such as person names, and to detect typos.
+Jaro-Winkler is a string edit distance that was developed in the area of record linkage (duplicate detection) (Winkler, 1990). The Jaro–Winkler distance metric is designed and best suited for short strings such as person names, and to detect transposition typos.
 
 Jaro-Winkler computes the similarity between 2 strings, and the returned value lies in the interval [0.0, 1.0].
-It is (roughly) a variation of Damerau-Levenshtein, where the substitution of 2 close characters is considered less important then the substitution of 2 characters that a far from each other.
+It is (roughly) a variation of Damerau-Levenshtein, where the transposition of 2 close characters is considered less important than the transposition of 2 characters that are far from each other. Jaro-Winkler penalizes additions or substitutions that cannot be expressed as transpositions.
 
 The distance is computed as 1 - Jaro-Winkler similarity.
 


### PR DESCRIPTION
The previous readme made it same like Jaro-Winkler was the ideal typo detector,
when in actuality it is really only suited for typos caused by unsynchronized
high-speed typing between between both hands but does not account for actual
miskey errors such as hitting the wrong key altogether or advertently pressing
two keys instead of one. This is because Jaro-Winkler operates only on
transpositions and does not favorably consider a string consisting strictly of
additions or permutations with letters not already part of the word's alphabet
to be "similar" changes.